### PR TITLE
Use fixed version of tabby-agent

### DIFF
--- a/src/tabby.rs
+++ b/src/tabby.rs
@@ -24,7 +24,7 @@ impl TabbyExtension {
             id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
+        let version = String::from("1.6.0");
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)


### PR DESCRIPTION
The latest version of `tabby-agent` doesn't seem to be working with this extension for some reason. I found that version `1.6.0` does, which appears to be the version used when this was initially written.